### PR TITLE
Tweak Circle CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,7 @@
+dependencies:
+  cache_directories:
+    - '~/.m2'
+
+test:
+  override:
+    - lein test # we don't trampoline with `:eval-in-leiningen`


### PR DESCRIPTION
- Only cache ~/.m2
- Avoid redundant use of trampoline
