### PR TITLE
Install schema always

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -e
+
+stage() {
+  echo
+  echo -e "\033[34;1m=>\033[0m $@"
+  echo
+}
+
+export TEMPLATE_DIR="/tmp/jcf-$(date -u +"%Y%m%d%H%M%S" | tr -d "\n")"
+
+stage "Running \"lein test\"..."
+lein test
+
+stage "Running \"lein new\"..."
+lein new jcf testing/things --to-dir "${TEMPLATE_DIR}"
+
+stage "Checking ${TEMPLATE_DIR} exists..."
+[[ -d "${TEMPLATE_DIR}" ]] ||
+  ( echo >&2 "$TEMPLATE_DIR is not a directory?!" ; exit 1 )
+
+ls -al "${TEMPLATE_DIR}"

--- a/circle.yml
+++ b/circle.yml
@@ -4,4 +4,4 @@ dependencies:
 
 test:
   override:
-    - lein test # we don't trampoline with `:eval-in-leiningen`
+    - bin/ci

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://opensource.org/licenses/MIT"}
   :deploy-repositories [["releases" :clojars]]
   :eval-in-leiningen true
+  :dependencies [[prismatic/schema "0.4.3"]]
   :profiles {:dev {:dependencies [[leiningen "2.5.1"]
                                   [me.raynes/fs "1.4.6"]
-                                  [org.clojure/clojure "1.7.0"]
-                                  [prismatic/schema "0.4.3"]]}})
+                                  [org.clojure/clojure "1.7.0"]]}})


### PR DESCRIPTION
Schema is required when running the template, but the dependency was only in the `:dev` profile. This change should result in Schema being installed along with the template assuming my understanding of Leiningen templates is accurate.

I've also tweaked the build to run `lein new` so we avoid mistakes like this in future.
