### PR TITLE
Use entire namespace when generating uberjar name

### DIFF
--- a/resources/leiningen/new/jcf/project.clj
+++ b/resources/leiningen/new/jcf/project.clj
@@ -6,7 +6,7 @@
                  [org.clojure/clojure "1.7.0"]
                  [prismatic/schema "0.4.3"]]
   :min-lein-version "2.5.0"
-  :uberjar-name "{{project-name}}-standalone.jar"
+  :uberjar-name "{{hyphenated-name}}-standalone.jar"
   :profiles
   {:dev {:dependencies [[org.clojure/tools.namespace "0.2.5"]
                         [reloaded.repl "0.1.0"]]

--- a/test/jcf/template_test.clj
+++ b/test/jcf/template_test.clj
@@ -20,7 +20,38 @@
                 {:name "example/app"
                  :ns "example.app"
                  :path "example/app"
-                 :project-name "app"}))
+                 :project-name "app"
+                 :hyphenated-name "example-app"}))
+
+(deftest test-name->data
+  (are [in out] (= (name->data in) out)
+    "foo"
+    {:hyphenated-name "foo"
+     :name "foo"
+     :ns "foo"
+     :path "foo"
+     :project-name "foo"}
+
+    "foo.app"
+    {:hyphenated-name "foo.app"
+     :name "foo.app"
+     :ns "foo.app"
+     :path "foo/app"
+     :project-name "foo.app"}
+
+    "foo/app"
+    {:hyphenated-name "foo-app"
+     :name "foo/app"
+     :ns "foo.app"
+     :path "foo/app"
+     :project-name "app"}
+
+    "foo/bar/app"
+    {:hyphenated-name "foo-bar-app"
+     :name "foo/bar/app"
+     :ns "foo.bar.app"
+     :path "foo/bar/app"
+     :project-name "app"}))
 
 (deftest test-render-files
   (is (= (-> manifest keys sort) expected-manifest)))

--- a/test/jcf/template_test.clj
+++ b/test/jcf/template_test.clj
@@ -30,6 +30,7 @@
         props (apply hash-map kvs)]
     (is (= named 'example/app))
     (is (= version "0.1.0-SNAPSHOT"))
+    (is (= (:uberjar-name props) "example-app-standalone.jar"))
     (is (= (:dependencies props)
            '[[com.stuartsierra/component "0.2.2"]
              [environ "1.0.0"]


### PR DESCRIPTION
Fixes #2.
