### PR TITLE
Default to the user namespace when starting a REPL

### DIFF
--- a/resources/leiningen/new/jcf/project.clj
+++ b/resources/leiningen/new/jcf/project.clj
@@ -7,6 +7,7 @@
                  [prismatic/schema "1.0.1"]]
   :main {{ns}}.main
   :min-lein-version "2.5.0"
+  :repl-options {:init-ns user}
   :uberjar-name "{{hyphenated-name}}-standalone.jar"
   :profiles
   {:dev {:dependencies [[org.clojure/tools.namespace "0.2.10"]

--- a/test/jcf/template_test.clj
+++ b/test/jcf/template_test.clj
@@ -60,6 +60,7 @@
         props (apply hash-map kvs)]
     (is (= named 'example/app))
     (is (= version "0.1.0-SNAPSHOT"))
+    (is (= (:repl-options props) '{:init-ns user}))
     (is (= (:uberjar-name props) "example-app-standalone.jar"))
     (is (= (:dependencies props)
            '[[com.stuartsierra/component "0.3.0"]


### PR DESCRIPTION
When we start a REPL we want to be in the `user` namespace because
that's where we keep all our lifecycle functions etc.
